### PR TITLE
Python SDK: documentation fixes (auth, account_id, retry)

### DIFF
--- a/python/.env.example
+++ b/python/.env.example
@@ -15,4 +15,4 @@ FINAM_SECRET=tapi_sk_replace_me
 #              from finam_trade_api.proto.grpc.tradeapi.v1.auth.auth_service_pb2 import TokenDetailsRequest; \
 #              c=FinamClient(secret='\$FINAM_SECRET'); \
 #              print(list(c.auth.TokenDetails(TokenDetailsRequest(token=c.token)).account_ids))"
-FINAM_ACCOUNT_ID=1234567
+FINAM_ACCOUNT_ID=TRQD05:123456

--- a/python/.env.example
+++ b/python/.env.example
@@ -10,9 +10,10 @@
 FINAM_SECRET=tapi_sk_replace_me
 
 # A real Finam account number visible to FINAM_SECRET.
-# Discover yours by running:
-#   python -c "from finam_trade_api import FinamClient; \
-#              from finam_trade_api.proto.grpc.tradeapi.v1.auth.auth_service_pb2 import TokenDetailsRequest; \
-#              c=FinamClient(secret='\$FINAM_SECRET'); \
-#              print(list(c.auth.TokenDetails(TokenDetailsRequest(token=c.token)).account_ids))"
+# Discover yours (after sourcing .env) by running:
+#   python -c "import os; from finam_trade_api import FinamClient; \
+#              from finam_trade_api.auth_messages import TokenDetailsRequest; \
+#              c = FinamClient(secret=os.environ['FINAM_SECRET']); \
+#              print(list(c.auth.TokenDetails(TokenDetailsRequest(token=c.get_token())).account_ids)); \
+#              c.close()"
 FINAM_ACCOUNT_ID=TRQD05:123456

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # Finam Trade API — Python SDK
 
-Thin Python SDK for the [Finam Trade API](https://tradeapi.finam.ru/). Wraps
+Thin Python SDK for the [Finam Trade API](https://api.finam.ru/). Wraps
 the generated gRPC stubs with:
 
 - a single `FinamClient` / `AsyncFinamClient` entry point,
@@ -24,11 +24,13 @@ pip install finam-sdk
 ## Quickstart (sync)
 
 ```python
+import os
+
 from finam_trade_api import FinamClient
 from finam_trade_api.accounts import GetAccountRequest
 from finam_trade_api.market_data import SubscribeQuoteRequest
 
-with FinamClient(secret="YOUR_API_TOKEN") as client:
+with FinamClient(secret=os.environ["FINAM_SECRET"]) as client:
     account = client.accounts.GetAccount(GetAccountRequest(account_id="TRQD05:123456"))
     print(account)
 
@@ -39,17 +41,24 @@ with FinamClient(secret="YOUR_API_TOKEN") as client:
         print(tick)
 ```
 
+The snippets in this README read your API secret from the `FINAM_SECRET`
+environment variable (see `.env.example`) instead of hardcoding it.
+
+Don't know your `account_id`? See
+[Finding your `account_id`](#finding-your-account_id) below.
+
 ## Quickstart (asyncio)
 
 ```python
 import asyncio
+import os
 
 from finam_trade_api import AsyncFinamClient
 from finam_trade_api.market_data import SubscribeQuoteRequest
 
 
 async def main() -> None:
-    async with AsyncFinamClient(secret="YOUR_API_TOKEN") as client:
+    async with AsyncFinamClient(secret=os.environ["FINAM_SECRET"]) as client:
         async for tick in client.market_data.SubscribeQuote(
             SubscribeQuoteRequest(symbols=["SBER@MISX"])
         ):
@@ -65,7 +74,7 @@ You never call the auth RPC yourself — the client does it for you. You only
 supply your API secret:
 
 ```python
-with FinamClient(secret="YOUR_API_TOKEN") as client:
+with FinamClient(secret=os.environ["FINAM_SECRET"]) as client:
     ...
 ```
 
@@ -89,14 +98,16 @@ with `client.get_token()`.
 
 ## Finding your `account_id`
 
-Most calls take an `account_id` (format `TRQD05:123456`). To list the accounts
-your secret can see, inspect the token:
+Most calls take an `account_id` (format `TRQD05:123456`). The accounts your
+secret can see are listed in `TokenDetails.account_ids` — inspect the token:
 
 ```python
+import os
+
 from finam_trade_api import FinamClient
 from finam_trade_api.auth_messages import TokenDetailsRequest
 
-with FinamClient(secret="YOUR_API_TOKEN") as client:
+with FinamClient(secret=os.environ["FINAM_SECRET"]) as client:
     details = client.auth.TokenDetails(TokenDetailsRequest(token=client.get_token()))
     print(details.account_ids)  # ['TRQD05:123456']
 ```
@@ -226,10 +237,12 @@ Legend: ▶ unary · ⇉ server-stream · ⇄ bidi-stream
 Wrap raw `grpc.RpcError` into a typed `FinamError`:
 
 ```python
+import os
+
 import grpc
 from finam_trade_api import FinamClient, RateLimitError, from_rpc_error
 
-with FinamClient(secret="...") as client:
+with FinamClient(secret=os.environ["FINAM_SECRET"]) as client:
     try:
         client.accounts.GetAccount(GetAccountRequest(account_id="TRQD05:123456"))
     except grpc.RpcError as raw:
@@ -256,10 +269,12 @@ the caller is expected to handle reconnection at a meaningful boundary
 Override the policy:
 
 ```python
+import os
+
 from finam_trade_api import FinamClient, RetryPolicy
 
 policy = RetryPolicy(max_attempts=6, initial_backoff=0.5, max_backoff=10.0)
-client = FinamClient(secret="...", retry_policy=policy)
+client = FinamClient(secret=os.environ["FINAM_SECRET"], retry_policy=policy)
 ```
 
 ## Local build

--- a/python/README.md
+++ b/python/README.md
@@ -59,6 +59,48 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+## Authentication
+
+You never call the auth RPC yourself — the client does it for you. You only
+supply your API secret:
+
+```python
+with FinamClient(secret="YOUR_API_TOKEN") as client:
+    ...
+```
+
+On construction the client:
+
+1. Exchanges your secret for a short-lived JWT via `AuthService.Auth`. The sync
+   `FinamClient` blocks until this succeeds; `AsyncFinamClient` performs it
+   inside `await client.start()`.
+2. Keeps the JWT fresh in the background by consuming the
+   `AuthService.SubscribeJwtRenewal` stream (a daemon thread for the sync
+   client, an asyncio task for the async one), reconnecting with backoff.
+3. Attaches the current JWT to the `Authorization` metadata of every RPC, so
+   token refreshes between calls are transparent.
+
+A bad or empty secret raises `AuthError` at construction, before the client is
+returned.
+
+You normally never handle the JWT yourself. If you need the raw token — for
+example to authorize a separate WebSocket connection — read the cached snapshot
+with `client.get_token()`.
+
+## Finding your `account_id`
+
+Most calls take an `account_id` (format `TRQD05:123456`). To list the accounts
+your secret can see, inspect the token:
+
+```python
+from finam_trade_api import FinamClient
+from finam_trade_api.auth_messages import TokenDetailsRequest
+
+with FinamClient(secret="YOUR_API_TOKEN") as client:
+    details = client.auth.TokenDetails(TokenDetailsRequest(token=client.get_token()))
+    print(details.account_ids)  # ['TRQD05:123456']
+```
+
 ## Available services
 
 The client exposes the full Trade API surface via sub-clients:

--- a/python/README.md
+++ b/python/README.md
@@ -29,7 +29,7 @@ from finam_trade_api.accounts import GetAccountRequest
 from finam_trade_api.market_data import SubscribeQuoteRequest
 
 with FinamClient(secret="YOUR_API_TOKEN") as client:
-    account = client.accounts.GetAccount(GetAccountRequest(account_id="A12345"))
+    account = client.accounts.GetAccount(GetAccountRequest(account_id="TRQD05:123456"))
     print(account)
 
     # Streaming RPCs return iterators.
@@ -189,7 +189,7 @@ from finam_trade_api import FinamClient, RateLimitError, from_rpc_error
 
 with FinamClient(secret="...") as client:
     try:
-        client.accounts.GetAccount(GetAccountRequest(account_id="A12345"))
+        client.accounts.GetAccount(GetAccountRequest(account_id="TRQD05:123456"))
     except grpc.RpcError as raw:
         err = from_rpc_error(raw)
         if isinstance(err, RateLimitError):

--- a/python/README.md
+++ b/python/README.md
@@ -6,7 +6,7 @@ the generated gRPC stubs with:
 - a single `FinamClient` / `AsyncFinamClient` entry point,
 - automatic JWT issuance and background refresh (via `AuthService.SubscribeJwtRenewal`),
 - typed exceptions mapped from gRPC status codes,
-- exponential-backoff retries on transient failures (`UNAVAILABLE`, `RESOURCE_EXHAUSTED`).
+- exponential-backoff retries on transient failures (`UNAVAILABLE`; `RESOURCE_EXHAUSTED` only on server pushback).
 
 Service methods are invoked directly on the generated stubs, so the full proto
 surface is available without an extra translation layer.
@@ -246,9 +246,11 @@ All inherit from `FinamError`.
 
 ## Retries
 
-Unary RPCs are retried automatically on `UNAVAILABLE` and `RESOURCE_EXHAUSTED`
-with exponential backoff + jitter. Streaming RPCs are *not* retried — the
-caller is expected to handle reconnection at a meaningful boundary
+Unary RPCs are retried automatically on `UNAVAILABLE` with exponential backoff
++ jitter. `RESOURCE_EXHAUSTED` (429) is retried only when the server sends a
+`grpc-retry-pushback-ms` hint (using that delay); without it a 429 is surfaced
+immediately, to avoid amplifying throttling. Streaming RPCs are *not* retried —
+the caller is expected to handle reconnection at a meaningful boundary
 (e.g. resuming from the last received bar).
 
 Override the policy:

--- a/python/finam_trade_api/accounts.py
+++ b/python/finam_trade_api/accounts.py
@@ -5,7 +5,7 @@ Re-exports the proto request/response messages used with
 deeply nested generated module path.
 
     from finam_trade_api.accounts import GetAccountRequest
-    client.accounts.GetAccount(GetAccountRequest(account_id="A12345"))
+    client.accounts.GetAccount(GetAccountRequest(account_id="TRQD05:123456"))
 """
 
 from .proto.grpc.tradeapi.v1.accounts.accounts_service_pb2 import (

--- a/python/finam_trade_api/aio.py
+++ b/python/finam_trade_api/aio.py
@@ -4,7 +4,7 @@ Mirrors the sync client one-to-one, using grpc.aio under the hood. Streaming
 RPCs return async iterators that can be consumed with ``async for``.
 
     async with AsyncFinamClient(secret="...") as client:
-        accounts = await client.accounts.GetAccount(GetAccountRequest(account_id="A12345"))
+        accounts = await client.accounts.GetAccount(GetAccountRequest(account_id="TRQD05:123456"))
         async for tick in client.market_data.SubscribeQuote(SubscribeQuoteRequest(symbol="SBER@MISX")):
             ...
 """

--- a/python/finam_trade_api/client.py
+++ b/python/finam_trade_api/client.py
@@ -6,7 +6,7 @@ invoke generated methods directly with proto messages — the wrapper only
 takes care of channel setup, authentication, retries, and error mapping.
 
     with FinamClient(secret="...") as client:
-        accounts = client.accounts.GetAccount(GetAccountRequest(account_id="A12345"))
+        accounts = client.accounts.GetAccount(GetAccountRequest(account_id="TRQD05:123456"))
         for tick in client.market_data.SubscribeQuote(SubscribeQuoteRequest(symbol="SBER@MISX")):
             ...
 """

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/FinamWeb/finam-trade-api"
-Documentation = "https://tradeapi.finam.ru/"
+Documentation = "https://api.finam.ru/"
 Repository = "https://github.com/FinamWeb/finam-trade-api"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Documentation-only changes for the Python SDK (from the FTD-24215 review). No code/logic touched.

- **Authentication** — new section explaining the automatic `secret → JWT → background refresh` flow, so it's clear the auth step isn't missing, just encapsulated.
- **account_id** — new "Finding your account_id" section (via `TokenDetails`); replaced the placeholder `A12345` with the real format `TRQD05:123456` across README, docstrings and `.env.example`.
- **Retries** — corrected the `RESOURCE_EXHAUSTED` description: it is retried only on server `grpc-retry-pushback-ms`, not unconditionally.
