### PR TITLE
Use OIDC for publish npm package

### DIFF
--- a/.github/workflows/publish_js_proto.yml
+++ b/.github/workflows/publish_js_proto.yml
@@ -5,22 +5,24 @@ on:
     types: [created]
   workflow_dispatch:
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     defaults:
       run:
         working-directory: js
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false  # never use caching in release builds
 
       - name: Install dependencies
         run: npm ci
@@ -30,5 +32,3 @@ jobs:
 
       - name: Publish to npm
         run: npm run publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Настраиваю по инструкции https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
и вроде указывать токен для npm не нужно теперь