### PR TITLE
Expose corporate actions stub in Kotlin client

### DIFF
--- a/kotlin/sdk/src/main/kotlin/ru/finam/tradeapi/client.kt
+++ b/kotlin/sdk/src/main/kotlin/ru/finam/tradeapi/client.kt
@@ -7,6 +7,7 @@ import grpc.tradeapi.v1.auth.AuthServiceGrpcKt
 import grpc.tradeapi.v1.auth.SubscribeJwtRenewalRequest
 import grpc.tradeapi.v1.auth.TokenDetailsRequest
 import grpc.tradeapi.v1.auth.TokenDetailsResponse
+import grpc.tradeapi.v1.corporateactions.CorporateActionsServiceGrpcKt
 import grpc.tradeapi.v1.marketdata.MarketDataServiceGrpcKt
 import grpc.tradeapi.v1.orders.OrdersServiceGrpcKt
 import io.grpc.ManagedChannel
@@ -113,6 +114,9 @@ class TradeAPIClient(
 
     fun authServiceStub(): AuthServiceGrpcKt.AuthServiceCoroutineStub =
         AuthServiceGrpcKt.AuthServiceCoroutineStub(grpc)
+
+    fun corporateActionsServiceStub(): CorporateActionsServiceGrpcKt.CorporateActionsServiceCoroutineStub =
+        CorporateActionsServiceGrpcKt.CorporateActionsServiceCoroutineStub(grpc).authorized()
 
     fun marketDataServiceStub(): MarketDataServiceGrpcKt.MarketDataServiceCoroutineStub =
         MarketDataServiceGrpcKt.MarketDataServiceCoroutineStub(grpc).authorized()


### PR DESCRIPTION
## Summary

- Expose the generated `CorporateActionsServiceCoroutineStub` through `TradeAPIClient`.
- Apply the same authorization metadata interceptor used by the other authenticated service stubs.
- Complete the Kotlin SDK client integration for the corporate actions proto functionality introduced in version 2.16.0.

## Testing

- `./gradlew :sdk:check`